### PR TITLE
Improve buffer management and remove unnecessary function call in `sos-get-response-body`

### DIFF
--- a/sos.el
+++ b/sos.el
@@ -74,12 +74,14 @@ Returns the buffer of the uncompressed gzipped content."
 
 Modified based on fogbugz-mode, renamed from
 `fogbugz-get-response-body'."
-  (set-buffer buffer)
-  (switch-to-buffer buffer)
-  (let* ((uncompressed-buffer (sos-uncompress-callback))
-         (json-response (json-read)))
-    (kill-buffer uncompressed-buffer)
-    json-response))
+  (with-current-buffer buffer
+    (let* ((uncompressed-buffer (sos-uncompress-callback))
+           (json-response (progn
+                            (set-buffer uncompressed-buffer)
+                            (json-read))))
+      (kill-buffer uncompressed-buffer)
+      json-response)))
+
 
 (defun sos-insert-search-result (item)
   "Inserts the contents of StackOverflow JSON object, `item',


### PR DESCRIPTION
* Use [`with-current-buffer`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Current-Buffer.html) to ensure proper buffer management
* Remove the unnecessary [`switch-to-buffer`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Switching-Buffers.html) call, as it doesn't impact the function's functionality